### PR TITLE
Update tool names in admin category for consistency

### DIFF
--- a/just_in_time_access_proactive/jit_tools/initialization/__init__.py
+++ b/just_in_time_access_proactive/jit_tools/initialization/__init__.py
@@ -15,11 +15,10 @@ default allow = false
 # Tool Categories
 tool_categories := {
     "admin": {
-        "approve_access_tool",
-        "describe_access_request_tool",
-        "list_active_access_requests_tool",
-        "request_access_tool",
-        "view_user_requests_tool"
+        "list_active_access_requests",
+        "view_user_requests",
+        "approve_tool_access_request",
+        "describe_access_request"
     },
     "revoke": {${revoke_tools}},
     "restricted": {${restricted_tools}}


### PR DESCRIPTION
Renamed tools in the "admin" category to align with a consistent naming convention. This improves readability and standardization across the codebase. No functional changes were introduced.