### PR TITLE
Add tool to change Jira ticket status

### DIFF
--- a/jira/jira_tools/tools/__init__.py
+++ b/jira/jira_tools/tools/__init__.py
@@ -1,1 +1,2 @@
 from .issues import *
+from . import change_issue_status

--- a/jira/jira_tools/tools/change_issue_status.py
+++ b/jira/jira_tools/tools/change_issue_status.py
@@ -1,0 +1,80 @@
+import argparse
+import json
+import requests
+import sys
+from basic_funcs import get_jira_cloud_id, get_jira_basic_headers, ATLASSIAN_JIRA_API_URL
+
+
+def get_available_transitions(issue_key):
+    """Get all available transitions for a given issue"""
+    jira_cloud_id = get_jira_cloud_id()
+    transitions_url = f"{ATLASSIAN_JIRA_API_URL}/{jira_cloud_id}/rest/api/3/issue/{issue_key}/transitions"
+    
+    headers = get_jira_basic_headers()
+    
+    try:
+        response = requests.get(transitions_url, headers=headers)
+        response.raise_for_status()
+        return response.json()["transitions"]
+    except requests.exceptions.HTTPError as e:
+        print(f"Failed to get transitions: {e}")
+        sys.exit(1)
+
+
+def change_issue_status(issue_key, status_name):
+    """Change the status of a Jira issue"""
+    jira_cloud_id = get_jira_cloud_id()
+    transitions_url = f"{ATLASSIAN_JIRA_API_URL}/{jira_cloud_id}/rest/api/3/issue/{issue_key}/transitions"
+    
+    headers = get_jira_basic_headers()
+    
+    # Get available transitions
+    transitions = get_available_transitions(issue_key)
+    
+    # Find the transition that matches the requested status name
+    transition_id = None
+    for transition in transitions:
+        if transition["to"]["name"].lower() == status_name.lower():
+            transition_id = transition["id"]
+            break
+    
+    if not transition_id:
+        available_statuses = ", ".join([t["to"]["name"] for t in transitions])
+        print(f"Error: Status '{status_name}' not found. Available statuses: {available_statuses}")
+        sys.exit(1)
+    
+    # Prepare the payload
+    payload = {
+        "transition": {
+            "id": transition_id
+        }
+    }
+    
+    try:
+        response = requests.post(transitions_url, headers=headers, data=json.dumps(payload))
+        response.raise_for_status()
+        print(f"Successfully changed '{issue_key}' status to '{status_name}'")
+    except requests.exceptions.HTTPError as e:
+        print(f"Failed to change issue status: {e}")
+        sys.exit(1)
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Change the status of a Jira issue')
+    parser.add_argument('issue_key', type=str, help='The Jira issue key (e.g., PROJ-123)')
+    parser.add_argument('status', type=str, help='The target status (e.g., "In Progress", "Done")')
+    parser.add_argument('--list-transitions', action='store_true', help='List available transitions only')
+    
+    args = parser.parse_args()
+    
+    if args.list_transitions:
+        transitions = get_available_transitions(args.issue_key)
+        print("Available transitions:")
+        for transition in transitions:
+            print(f"- {transition['to']['name']}")
+    else:
+        change_issue_status(args.issue_key, args.status)
+
+
+if __name__ == "__main__":
+    main() 

--- a/jira/jira_tools/tools/issues.py
+++ b/jira/jira_tools/tools/issues.py
@@ -2,7 +2,7 @@ import inspect
 from typing import List
 from kubiya_sdk.tools import Arg, FileSpec
 from ..base import JiraPythonTool, register_jira_tool
-from . import create_issue, basic_funcs, view_issue, list_issues, create_issue_comment
+from . import create_issue, basic_funcs, view_issue, list_issues, create_issue_comment, change_issue_status
 
 
 class BaseCreationIssueTool(JiraPythonTool):
@@ -128,6 +128,26 @@ add_comment_issue_tool = JiraPythonTool(
         )
     ])
 
+change_issue_status_tool = JiraPythonTool(
+    name="issue_change_status",
+    description="Change the status of a Jira issue",
+    content="""python /tmp/change_issue_status.py "{{ .issue_key }}" "{{ .status }}" {{ if .list_transitions }}--list-transitions{{ end }}""",
+    args=[
+        Arg(name="issue_key", type="str", description="Issue key (e.g., 'PROJ-123')", required=True),
+        Arg(name="status", type="str", description="The target status (e.g., 'In Progress', 'Done')", required=True),
+        Arg(name="list_transitions", type="bool", description="List available transitions only", required=False),
+    ],
+    with_files=[
+        FileSpec(
+            destination="/tmp/change_issue_status.py",
+            content=inspect.getsource(change_issue_status),
+        ),
+        FileSpec(
+            destination="/tmp/basic_funcs.py",
+            content=inspect.getsource(basic_funcs),
+        )
+    ])
+
 [
     register_jira_tool(tool) for tool in [
         create_task_tool,
@@ -137,6 +157,7 @@ add_comment_issue_tool = JiraPythonTool(
         create_story_tool,
         view_issue_tool,
         list_issue_tool,
-        add_comment_issue_tool
+        add_comment_issue_tool,
+        change_issue_status_tool
     ]
 ]


### PR DESCRIPTION
This PR adds a new tool to the Jira integration that allows changing the status of a Jira ticket. The tool provides functionality to change ticket status and list available transitions.